### PR TITLE
[Feat]: 이름이 한국 형식으로 나오게 변경

### DIFF
--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -1,6 +1,35 @@
 from django.apps import AppConfig
-
+from django.conf import settings
 
 class AccountsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'accounts'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "accounts"
+
+    def ready(self):
+        # settings.py에서 제어 가능
+        # from django.contrib.auth.models import User
+        
+        if getattr(settings, "USE_KOREAN_NAME_FORMAT", True):
+            self.setup_korean_name_format()
+
+    def setup_korean_name_format(self):
+        from django.contrib.auth.models import User
+        # 원본 저장
+        User._original_get_full_name = User.get_full_name
+        User._original_get_short_name = User.get_short_name
+
+        def korean_get_full_name(self):
+            if self.first_name and self.last_name:
+                return f"{self.last_name}{self.first_name}".strip()
+            elif self.last_name:
+                return self.last_name
+            elif self.first_name:
+                return self.first_name
+            return self.username
+
+        def korean_get_short_name(self):
+            # 성만 변환 (한국식)
+            return self.last_name or self.first_name or self.username
+
+        User.get_full_name = korean_get_full_name
+        User.get_short_name = korean_get_short_name

--- a/config/settings.py
+++ b/config/settings.py
@@ -252,4 +252,6 @@ DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 EMAIL_TIMEOUT = 30  # 30초 타임아웃
 EMAIL_CONNECTION_USE_TLS = True
 
+# User의 get_full_name 메서드를 한국 이름으로 설정
+USE_KOREAN_NAME_FORMAT = True
 


### PR DESCRIPTION
### 문제
기존에는 `User` 의 `get_full_name` 메서드를 사용하였기 때문에, `길동 홍` 과 같은 형식으로 이름이 나왔음. `홍길동` 과 같은 형식의 이름이 나와야됨.

### 고려 방안
- 메서드 추가: get_full_name 을 사용하는 모든 부분의 코드를 변경해야됨.
- custom user model: 프로젝트가 진행이 된 상태여서 적용이 힘듬

### 해결방법
accounts/apps.py의 `AccountsConfig` 클래스에서, `User` 모델의 `get_full_name` 메서드와 `get_short_name` 메서드를 오버라이드 진행.